### PR TITLE
[#1] feat: 버튼 컴포넌트 구현

### DIFF
--- a/src/app/demo/button/page.tsx
+++ b/src/app/demo/button/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import React from "react";
+import Button from "@/components/common/button/Button";
+
+export default function ButtonDemoPage() {
+  return (
+    <main className="p-6 grid gap-4">
+      <section className="flex gap-3 items-center">
+          <Button size="xs">인증번호받기</Button>
+          <Button size="sm" disabled>다음</Button>
+          <Button size="md">BDAI 공식 페이지 바로가기</Button>
+          <Button size="lg">GO!</Button>
+      </section>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,11 @@
 @import "tailwindcss";
 
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -10,11 +16,29 @@
   --color-foreground: var(--foreground);
   --font-sans: var(--font-geist-sans);
   --font-mono: var(--font-geist-mono);
+
+  /* Primary Color */
+  --color-primary-100: #5353e0;
+  --color-primary-200: #3e3ea8;
+  --color-primary-300: #2f2f7e;
+
+  /* Secondary Color */
+  --color-secondary-100: #fff24d;
+  --color-secondary-200: #e8604b;
+
+  /* Gray Color */
+  --color-gray-100: #f8f8f8;
+  --color-gray-200: #d1d1d1;
+  --color-gray-300: #ababab;
+  --color-gray-400: #656565;
+  --color-gray-500: #4c4c4c;
+  --color-gray-600: #1a1a1a;
+  --color-gray-700: #000000;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #ffffff;
     --foreground: #ededed;
   }
 }

--- a/src/components/common/button/Button.tsx
+++ b/src/components/common/button/Button.tsx
@@ -1,0 +1,26 @@
+import { ButtonProps } from "@/types/common/button";
+import React from "react";
+
+export function Button({ children, disabled, size = "md", onClick, className, ...restProps }: ButtonProps) {
+  const base =
+    "bg-primary-100 hover:bg-primary-300 disabled:bg-gray-200 text-white inline-flex items-center justify-center rounded-[18px] font-bold transition-colors";
+  const sizes: Record<NonNullable<ButtonProps["size"]>, string> = {
+    xs: "h-[60px] w-[105px] text-[16px]",
+    sm: "h-[65px] w-[150px] text-[24px]",
+    md: "h-[50px] w-[273px] text-[20px]",
+    lg: "h-[130px] w-[98px] text-[24px]",
+  };
+
+  return (
+    <button
+      disabled={disabled}
+      className={[base, sizes[size], className].filter(Boolean).join(" ")}
+      {...restProps}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default Button;

--- a/src/types/common/button.ts
+++ b/src/types/common/button.ts
@@ -1,0 +1,9 @@
+import React from "react";
+
+export interface ButtonProps {
+  size?: "xs" | "sm" | "md" | "lg";
+  disabled?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+  className?: string;
+}


### PR DESCRIPTION
## ✅ 주요 작업 내용
- 버튼 컴포넌트 구현

## 🔄 관련 이슈
Closes #1

## 📸 스크린샷
<img width="1066" height="230" alt="image" src="https://github.com/user-attachments/assets/39900ee4-b758-41e9-9d04-b502f2fcfdfa" />

## 📝 비고
- /demo/button 에서 button 컴포넌트 확인 가능
- 주석으로 하려고했으나 코드의 간결함을 위해 테스트 페이지에 작성했습니다. 추후에 삭제할 예정입니다.